### PR TITLE
Upgrade casbin to 1.1.2

### DIFF
--- a/flask_casbin/manager.py
+++ b/flask_casbin/manager.py
@@ -42,5 +42,4 @@ class CasbinManager(object):
         ctx.enforcer = casbin.Enforcer(
             current_app.config.get("CASBIN_MODEL_CONF"),
             self.policy_callback(),
-            current_app.debug or current_app.testing
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 flask = "^1.1"
-casbin = "^0.8.1"
+casbin = "^1.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
This is to fix #2 .

I'm not sure what to do with the lock file, as poetry seems to recommend to not version it for a library (as opposed to an app) : https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
